### PR TITLE
Add Calcmatic to the list of tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@
 - [aShop](https://ashop.co) - Effortless microsites for Amazon Sellers. Marketing tool that delivers branded store experience to bring more business and maximize profits.
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.
 - [BQool](https://www.bqool.com/) - Scheduled repricing, compete against buy box price, comprehensive dashboard & reports, repricing history log.
+- [Calcmatic](https://calcmatic.app) - Free profit calculator for Amazon FBA/FBM with full fee breakdown with graphs.
 - [CashCowPro](https://www.cashcowpro.com/) - Sales data, keyword tracking, feedback collection, inventory monitoring, price split testing.
 - [DataHawk](https://www.datahawk.co/) - An end-to-end platform, with full data control, intuitive dashboards and AI-powered guidance and automation.
 - [Eva](https://eva.guru/) - Connects the most important aspects of your Amazon business into a single intuitive dashboard - price management, replenishments, reimbursements, analytics.


### PR DESCRIPTION
Adding Calcmatic.app - a free Amazon FBA/FBM profit calculator with visual fee breakdown graphs.
	•	Free to use, no signup required
	•	Also supports Etsy and eBay for cross-platform sellers
	•	Calculates referral fees, FBA fees, shipping costs, and true profit margins