### PR TITLE
Add Snaplert to Software and Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@
 - [Prestozon](https://prestozon.com/) - Automation and analytics for Amazon HSA & sponsored products ads.
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.
+- [Snaplert](https://snaplert.com) - Website change monitoring with AI-powered visual diffs and email alerts. Track competitor pages, pricing, and product listings with before/after screenshots.
 - [SellerApp](https://www.sellerapp.com/) - Product research, product ideas, listing quality, product alerts, product source, keyword research, ppc analyzer, and more.
 - [SellerLabs](https://www.sellerlabs.com/tools/) - Several tools to manage ads, discover profitable keywords and products, get more product reviews and better seller feedback, simplify inventory and financial management for the amazon marketplace.
 - [SellerLegend](https://sellerlegend.com/) - Near real-time orders download, intelligent KPI dashboards, inventory management, notifications, refunds, historical cost of goods, operating expenses, all America & Europe marketplaces, financial transactions, Europe vat.


### PR DESCRIPTION
## What's added

[Snaplert](https://snaplert.com) added to the Software and Tools section.

## Why

Amazon sellers can use Snaplert to monitor competitor product pages, pricing, and listings for changes. It provides AI-powered visual diffs with email alerts and before/after screenshots — useful for tracking when competitors update their prices, product descriptions, or promotions. Free during open beta.

Fits alongside Prisync and Scrappie as a website monitoring tool for competitive analysis.