### PR TITLE
Add chdh-tools-dataset to Other section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@
 
 ## Other
 
+- [chdh-tools-dataset](https://github.com/launotice-lang/chdh-tools-dataset) - Open dataset (CC BY 4.0) of 1,210 cross-border e-commerce tools, including major Amazon seller tools (Helium 10, Jungle Scout, Keepa, FastMoss). JSON/CSV format with categories, pricing, and editorial ratings.
 - [FBA Catalog](https://fbacatalog.com) - Software catalog for Amazon Sellers. Find tools that fit your business in no time!
 - [FBA Monthly](https://fbamonthly.com) - FBA Monthly newsletter is an across-the-board summary of the month's most important news articles and blog posts regarding Amazon businesses.
 - [r/FulfillmentByAmazon](https://www.reddit.com/r/FulfillmentByAmazon/) - Subreddit for FBA sellers.


### PR DESCRIPTION
## What's added

[`chdh-tools-dataset`](https://github.com/launotice-lang/chdh-tools-dataset) — an open CC BY 4.0 dataset of **1,210 cross-border e-commerce tools** in JSON/CSV format.

## Why it's awesome for Amazon sellers

The dataset includes major Amazon seller tools already on this list (Helium 10, Jungle Scout, Keepa) plus many others, with structured metadata:

- Categories & sub-categories (15 main / 119 sub)
- Pricing models (free / freemium / trial / paid / contact)
- Editorial ratings (1-5)
- Founded year, headquarters, tags, features
- Direct links to in-depth editorial reviews

Useful for:
- Amazon seller research (compare tools across categories programmatically)
- Building comparison sites or chatbot recommendations
- Data-driven market analysis of the Amazon seller tool ecosystem
- AI/ML training data for tool recommendation systems

## How it fits the existing 'Other' section

Similar in nature to [500K ASIN Lists](https://app.turbopiranha.com/Download/bestselleritems) — a free, downloadable, structured data resource (not a SaaS tool).

## Notes

- Insertion is in alphabetical order (`c` before `F`).
- Description avoids marketing tone, states facts only.
- License is CC BY 4.0 (commercial use OK with attribution).
- Editorial reviews referenced in the dataset are at [chdh.me](https://chdh.me) (Chinese-language); the dataset itself has English README and metadata field names.

Thanks for maintaining this list! 🙏