### PR TITLE
Add amztool — open-web Sponsored Products bulk-sheet generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 - [Advigator](https://www.advigator.com) - Amazon Advertising Software
 - [AiHello AutoPilot](https://www.aihello.com/) - Amazon PPC Ads Automation Software.
 - [Amzmailer](https://amzmailer.com/) - Feedback software and email autoresponder to send Amazon customers automated emails.
+- - [amztool](https://amztool.me) - Open-web Sponsored Products bulk-sheet generator. Reusable keyword dictionaries, one-click ad-group cloning, exports upload-ready .xlsx. Free tier. Companion [open spec](https://github.com/lizhl6/amazon-sp-bulk-sheet-spec) describes the schema.
 - [aShop](https://ashop.co) - Effortless microsites for Amazon Sellers. Marketing tool that delivers branded store experience to bring more business and maximize profits.
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.
 - [BQool](https://www.bqool.com/) - Scheduled repricing, compete against buy box price, comprehensive dashboard & reports, repricing history log.


### PR DESCRIPTION
Adding **[amztool](https://amztool.me)** — an open-web Amazon Sponsored Products bulk-sheet generator.

**What it does**:
- Reusable keyword dictionaries (define once, fill any ad group with one click)
- One-click ad-group / campaign cloning across products
- Exports an Amazon-Ads-console-ready `.xlsx` matching the official bulk-operations format
- Live demo at [amztool.me/how-it-works](https://amztool.me/how-it-works) — no signup needed
- Free tier covers small accounts

**Why it might be useful in this list**: most existing tools listed are SaaS suites with subscription paywalls. amztool fills the gap for sellers who want a focused bulk-sheet generator they can try without account creation.

**Companion open spec**: I've also published [amazon-sp-bulk-sheet-spec](https://github.com/lizhl6/amazon-sp-bulk-sheet-spec) — a CC0-licensed JSON Schema + column reference for the Sponsored Products bulk-operations format.

Description tone follows existing entries — placement is alphabetical (between Amzmailer and aShop). I'm the author of amztool but submitting as a genuine user-facing tool, not a marketing landing page.