### PR TITLE
Add Packrift Packaging Fit Lab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@
 - [Jungle Scout](https://www.junglescout.com/) - Track and compare key product metrics, database allows you to filter products across multiple categories by demand, price, estimated sales, rating, seasonality, dimensions and more, find out which products sell and which niches have high opportunity.
 - [Keyword Tool](https://keywordtool.io/amazon) - Finds great keywords using Amazon autocomplete.
 - [MerchantWords](https://www.merchantwords.com/) - Finds highly specific keyword phrases that help buyers find what you are selling.
+- [Packrift Packaging Fit Lab](https://packrift.github.io/packaging-fit-lab/) - Free packaging fit tool for comparing item dimensions against carton and mailer options before FBA or merchant-fulfilled shipping.
 - [Prestozon](https://prestozon.com/) - Automation and analytics for Amazon HSA & sponsored products ads.
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.


### PR DESCRIPTION
Adds Packrift Packaging Fit Lab to the software/tools section for Amazon sellers.

The tool helps sellers compare item dimensions against carton and mailer options before FBA or merchant-fulfilled shipping, with exportable SKU review notes.

Validation:
- Confirmed the Fit Lab URL is public.
- Added the entry alphabetically.
- Ran `git diff --check`.
