### PR TITLE
Add Amazon Scraper API to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@
 - [Flapen](https://flapen.com) - Flapen is a free real-time dashboard to monitor Amazon category changes in 19 country and 215 categories
 - [Advigator](https://www.advigator.com) - Amazon Advertising Software
 - [AiHello AutoPilot](https://www.aihello.com/) - Amazon PPC Ads Automation Software.
+- [Amazon Scraper API](https://amazonscraperapi.com) - Production REST API for Amazon product, search, and batch ASIN data across 20 marketplaces. Residential proxies and TLS impersonation handled server-side. 1000 free requests on signup.
 - [Amzmailer](https://amzmailer.com/) - Feedback software and email autoresponder to send Amazon customers automated emails.
 - [aShop](https://ashop.co) - Effortless microsites for Amazon Sellers. Marketing tool that delivers branded store experience to bring more business and maximize profits.
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.


### PR DESCRIPTION
**What is this project?**
Amazon Scraper API is a managed REST API for scraping Amazon product detail pages, search results, and batch ASIN lookups across 20 marketplaces. It uses residential proxies, TLS impersonation, and returns clean JSON for downstream pipelines. Includes an MCP server (`amazon-scraper-api-mcp`) for AI agents and an n8n community node (`n8n-nodes-amazonscraperapi`).

**Why it fits this list?**
Direct fit for the Software and Tools section. Existing entries cover seller-focused data tools (DataHawk, Helium 10, Jungle Scout, Prisync, Scrappie) but none of them expose a developer REST API for raw Amazon product data, which sellers and agencies increasingly need for in-house dashboards, repricing, and review-monitoring pipelines.

**How it complies with the rules?**
- [x] Submission is genuinely useful for Amazon sellers building tooling
- [x] Inserted alphabetically between AiHello AutoPilot and Amzmailer
- [x] Description is factual; no marketing fluff
- [x] Not a guru course; not an affiliate link
- [x] Single line in the correct section