### PR TITLE
Add Ecommerce Profit Tracker PRO

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.
 - [BQool](https://www.bqool.com/) - Scheduled repricing, compete against buy box price, comprehensive dashboard & reports, repricing history log.
 - [Calcmatic](https://calcmatic.app) - Free profit calculator for Amazon FBA/FBM with full fee breakdown with graphs.
+- [Ecommerce Profit Tracker PRO](https://limin6661.github.io/ecommerce-profit-tracker/) - Spreadsheet-based profit and fee tracker for Amazon, Shopify, Etsy and eBay sellers. Calculates net profit per order in Excel or Google Sheets.
 - [CashCowPro](https://www.cashcowpro.com/) - Sales data, keyword tracking, feedback collection, inventory monitoring, price split testing.
 - [DataHawk](https://www.datahawk.co/) - An end-to-end platform, with full data control, intuitive dashboards and AI-powered guidance and automation.
 - [Eva](https://eva.guru/) - Connects the most important aspects of your Amazon business into a single intuitive dashboard - price management, replenishments, reimbursements, analytics.


### PR DESCRIPTION
Adds Ecommerce Profit Tracker PRO to the Software and Tools section (alphabetical, between Calcmatic and Eva).

It's a profit-and-fee calculator for Amazon (and multichannel) sellers, alongside Calcmatic and the existing analytics tools. Differentiator: a no-subscription Excel/Google Sheets workbook (one-time $19) rather than recurring SaaS. Following the precedent of packrift.github.io and calcmatic.app entries.

I built and use this myself. Non-affiliate link. Thanks for maintaining this list!