### PR TITLE
Add Calcrux FBA Profit Calculator to Calculators section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.
 - [BQool](https://www.bqool.com/) - Scheduled repricing, compete against buy box price, comprehensive dashboard & reports, repricing history log.
 - [Calcmatic](https://calcmatic.app) - Free profit calculator for Amazon FBA/FBM with full fee breakdown with graphs.
+- [Calcrux FBA Profit Calculator](https://calcrux.com/tools/ecommerce/amazon-fba-profit-calculator) - Free multi-marketplace FBA profit + fee breakdown calculator. Covers inbound placement fees. No sign-up required.
 - [CashCowPro](https://www.cashcowpro.com/) - Sales data, keyword tracking, feedback collection, inventory monitoring, price split testing.
 - [DataHawk](https://www.datahawk.co/) - An end-to-end platform, with full data control, intuitive dashboards and AI-powered guidance and automation.
 - [Eva](https://eva.guru/) - Connects the most important aspects of your Amazon business into a single intuitive dashboard - price management, replenishments, reimbursements, analytics.


### PR DESCRIPTION
Adding Calcrux's free Amazon FBA profit calculator to the Calculators section, following the format of the existing Calcmatic entry. 
What it does: Full fee breakdown — referral, fulfillment, storage, and inbound placement fees (a 2023+ Amazon charge that most calculators still miss) — with 2026-verified fee data. Multi-marketplace: US, UK, IN, DE, CA, AE, AU, SG, FR. No account required.