### PR TITLE
Add Inventory Hero to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@
 - [Helium10](https://www.helium10.com/) - Software suite contains over a dozen tools that help find high ranking keywords, identify trends, monitor competitors, and fully optimize product listings to increase sales.
 - [igly.ai](https://igly.ai/) - Free AI image editor with 12+ tools for e-commerce product photos. Background removal, image generation, inpainting, upscaling, and virtual try-on. Browser-based, no signup required.
 - [HelloProfit](https://helloprofit.com/) - Lets you view all your sales & profit data from different merchant accounts from one dashboard.
+- [Inventory Hero](https://www.inventoryhero.ai) - Automated inventory management for Amazon FBA that forecasts demand, drafts restocks, and works inside Claude via MCP.
 - [Jungle Scout](https://www.junglescout.com/) - Track and compare key product metrics, database allows you to filter products across multiple categories by demand, price, estimated sales, rating, seasonality, dimensions and more, find out which products sell and which niches have high opportunity.
 - [Keyword Tool](https://keywordtool.io/amazon) - Finds great keywords using Amazon autocomplete.
 - [MerchantWords](https://www.merchantwords.com/) - Finds highly specific keyword phrases that help buyers find what you are selling.


### PR DESCRIPTION
Adds Inventory Hero to the Software and Tools section.

Inventory Hero is automated inventory management for Amazon FBA. It forecasts demand, drafts restock orders and purchase orders for approval, and is the first FBA inventory tool that runs inside Claude via its own MCP server.

- Useful for Amazon sellers: inventory forecasting and restock planning
- Fits alongside existing entries like ForecastRx and SellerLegend (inventory) and Helium 10 / Jungle Scout
- Inserted alphabetically in Software and Tools (after HelloProfit)
- Factual description, not a course or affiliate link