### PR TITLE
Add product research and pre-launch resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 ## Contents
 
 - [Software and Tools](#software-and-tools)
+- [Product Research and Pre-Launch](#product-research-and-pre-launch)
 - [Podcasts](#podcasts)
 - [Blogs](#blogs)
 - [Other](#other)
@@ -52,6 +53,13 @@
 - [Turbo Piranha](https://www.turbopiranha.com/) - Bulk product search, profit calculation and competition analysis software using UPC, ISBN, EAN and ASIN lists in Excel/CSV/TXT format for wholesale and arbitrage business models, and also book sellers/flippers.
 - [WordTree](https://www.wordtree.io/) - Keyword tools to grow your search traffic, research your competitors, and monitor your niche.
 - [xSellco](https://www.xsellco.com/) - Centralize customer queries, target positive feedback by requesting reviews from happy customers, automatically reprice.
+
+## Product Research and Pre-Launch
+
+- [Amazon Product Opportunity Explorer](https://sell.amazon.com/tools/product-opportunity-explorer) - Official Amazon tool for exploring product opportunity niches and reviewing demand, competition, and search trends.
+- [Amazon Revenue Calculator](https://sell.amazon.com/tools) - Official Amazon tool for estimating selling fees, fulfillment costs, and revenue by fulfillment method.
+- [CPSC Regulatory Robot](https://www.cpsc.gov/Business--Manufacturing/Regulatory-Robot/Safer-Products-Start-Here) - U.S. Consumer Product Safety Commission tool that helps identify basic consumer product safety requirements.
+- [USPTO Patent Public Search](https://www.uspto.gov/patents/search/patent-public-search) - Official USPTO search tool for U.S. patents and patent application publications.
 
 ## Podcasts
 


### PR DESCRIPTION
## Summary

Adds a small Product Research and Pre-Launch section to help Amazon sellers find resources for early product validation before sourcing or launch.

Included resources:

- Amazon Product Opportunity Explorer
- Amazon Revenue Calculator
- CPSC Regulatory Robot
- USPTO Patent Public Search

## Why this is useful

Many sellers evaluate a product idea across demand, economics, compliance, and patent-risk checks before committing to sourcing or launch. This section gives those pre-launch checks a clearer home in the list without adding affiliate links or promotional resources.

Closes #36.

## Checks

- `git diff --check` passes.
- `npm test` currently fails on existing repository lint issues and older dead links. I removed one added link that the linter flagged, and the remaining failures appear unrelated to this PR.