### PR TITLE
Add BuyWhere — real-time product search & price comparison for Amazon sellers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@
 - [Amazon Scraper API](https://amazonscraperapi.com) - Production REST API for Amazon product, search, and batch ASIN data across 20 marketplaces. Residential proxies and TLS impersonation handled server-side. 1000 free requests on signup.
 - [Amzmailer](https://amzmailer.com/) - Feedback software and email autoresponder to send Amazon customers automated emails.
 - - [amztool](https://amztool.me) - Open-web Sponsored Products bulk-sheet generator. Reusable keyword dictionaries, one-click ad-group cloning, exports upload-ready .xlsx. Free tier. Companion [open spec](https://github.com/lizhl6/amazon-sp-bulk-sheet-spec) describes the schema.
+- [BuyWhere](https://buywhere.ai) - Real-time product search, price comparison, and deal discovery across Amazon, Best Buy, Walmart, and Target via MCP. 150M+ products, 88K+ merchants. Free API and CLI. [github](https://github.com/BuyWhere/buywhere-mcp)
 - [aShop](https://ashop.co) - Effortless microsites for Amazon Sellers. Marketing tool that delivers branded store experience to bring more business and maximize profits.
 - [ASINspector](https://asinspector.com/) - Sales trend data, unique product ideas, mobile scanner, best-seller rankings.
 - [BQool](https://www.bqool.com/) - Scheduled repricing, compete against buy box price, comprehensive dashboard & reports, repricing history log.


### PR DESCRIPTION
Adds BuyWhere to the Software and Tools section.

**BuyWhere** provides real-time product search, price comparison, and deal discovery across Amazon, Best Buy, Walmart, and Target via MCP.

- **Website:** https://buywhere.ai
- **GitHub:** https://github.com/BuyWhere/buywhere-mcp
- **npm:** `@buywhere/mcp-server`
- **PyPI:** `buywhere-mcp`
- **Stats:** 150M+ products, 88K+ merchants
- **Amazon tools:** search_products (barcode/ASIN/URL), get_deals, get_product_details

Useful for Amazon sellers doing competitor research, price monitoring, and market analysis across multiple retailers. Happy to adjust the entry. Thanks!