### PR TITLE
Add Acalcia (free no-signup money & tax calculators)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@
 
 ## Software and Tools
 - [Flapen](https://flapen.com) - Flapen is a free real-time dashboard to monitor Amazon category changes in 19 country and 215 categories
+- [Acalcia](https://acalcia.com) - Free, no-signup browser suite of seller calculators including an Amazon FBA fee and profit calculator, plus pricing, margin, and break-even tools. No login or paywall.
 - [Advigator](https://www.advigator.com) - Amazon Advertising Software
 - [AiHello AutoPilot](https://www.aihello.com/) - Amazon PPC Ads Automation Software.
 - [Amazon Scraper API](https://amazonscraperapi.com) - Production REST API for Amazon product, search, and batch ASIN data across 20 marketplaces. Residential proxies and TLS impersonation handled server-side. 1000 free requests on signup.


### PR DESCRIPTION
Adds [Acalcia](https://acalcia.com) — a free, no-signup suite of in-browser money & tax calculators for freelancers, online sellers, and creators (self-employment & quarterly tax, marketplace/payment fees, freelance rates, pricing, invoicing).

- Follows this list's existing entry format
- Single addition, not a duplicate (searched the list)
- Static, privacy-friendly, runs entirely in the browser — no signup, no paywall

Disclosure: I'm the maker. Thanks for curating this list!