### PR TITLE
Add SellerEngine.app to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.
 - [SellerApp](https://www.sellerapp.com/) - Product research, product ideas, listing quality, product alerts, product source, keyword research, ppc analyzer, and more.
+- [SellerEngine.app](https://sellerengine.app) - EU-hosted operations dashboard for multi-marketplace Amazon sellers; combines PPC, repricing, inventory forecasting, VAT/OSS and listing checks in one daily view.
 - [SellerLabs](https://www.sellerlabs.com/tools/) - Several tools to manage ads, discover profitable keywords and products, get more product reviews and better seller feedback, simplify inventory and financial management for the amazon marketplace.
 - [SellerLegend](https://sellerlegend.com/) - Near real-time orders download, intelligent KPI dashboards, inventory management, notifications, refunds, historical cost of goods, operating expenses, all America & Europe marketplaces, financial transactions, Europe vat.
 - [Sellics](https://sellics.com) - Combines everything you need to manage and grow your Amazon business in one integrated software. Features that work together to help you become more successful on Amazon.


### PR DESCRIPTION
Adds **SellerEngine.app** to *Software and Tools* (alphabetical, between SellerApp and SellerLabs).

Why it's a fit: it's an EU-hosted, all-in-one operations dashboard for multi-marketplace Amazon sellers — it combines PPC-waste control, margin-aware repricing, inventory forecasting, VAT/OSS reporting and listing health in a single daily view, which complements the mostly single-purpose tools already listed. Description kept factual per the contribution guidelines (no marketing, no affiliate links).