### PR TITLE
Add Awesome Agentic Commerce to Other

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@
 
 ## Other
 
+- [Awesome Agentic Commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) - Curated list of agentic commerce resources: protocols (ACP, UCP, MCP), agent-readiness testing tools, and guides on making products discoverable to AI shopping agents.
 - [chdh-tools-dataset](https://github.com/launotice-lang/chdh-tools-dataset) - Open dataset (CC BY 4.0) of 1,210 cross-border e-commerce tools, including major Amazon seller tools (Helium 10, Jungle Scout, Keepa, FastMoss). JSON/CSV format with categories, pricing, and editorial ratings.
 - [FBA Catalog](https://fbacatalog.com) - Software catalog for Amazon Sellers. Find tools that fit your business in no time!
 - [FBA Monthly](https://fbamonthly.com) - FBA Monthly newsletter is an across-the-board summary of the month's most important news articles and blog posts regarding Amazon businesses.


### PR DESCRIPTION
Adds [Awesome Agentic Commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) to the **Other** section (placed alphabetically, first entry).

Why it's a fit for this list: AI shopping agents (Rufus, ChatGPT shopping, Perplexity) are becoming a real discovery channel, and sellers increasingly ask how to show up in agent-driven search. This is a curated, actively maintained list covering the agentic commerce protocols (ACP, UCP, MCP), agent-readiness testing tools, and practical guides on making product listings discoverable to AI agents — a reference point for sellers who want to understand the space, similar in spirit to the newsletters and communities already in this section.

Follows the awesome list format (badge, linting) and the description stays factual per your guidelines. Happy to adjust wording or placement if you'd prefer it elsewhere.