### PR TITLE
Add multichannel-settlement to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@
 - [Jungle Scout](https://www.junglescout.com/) - Track and compare key product metrics, database allows you to filter products across multiple categories by demand, price, estimated sales, rating, seasonality, dimensions and more, find out which products sell and which niches have high opportunity.
 - [Keyword Tool](https://keywordtool.io/amazon) - Finds great keywords using Amazon autocomplete.
 - [MerchantWords](https://www.merchantwords.com/) - Finds highly specific keyword phrases that help buyers find what you are selling.
+- [multichannel-settlement](https://github.com/actorlee007-cmyk/multichannel-settlement) - Open-source command-line tool that reconciles order export CSVs from Amazon and other channels into one set of totals, drops cancelled and refunded rows, and applies per-channel fee rates. Python, no dependencies, runs locally.
 - [Packrift Packaging Fit Lab](https://packrift.github.io/packaging-fit-lab/) - Free packaging fit tool for comparing item dimensions against carton and mailer options before FBA or merchant-fulfilled shipping.
 - [Prestozon](https://prestozon.com/) - Automation and analytics for Amazon HSA & sponsored products ads.
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.


### PR DESCRIPTION
## Why this is awesome

Sellers who list on Amazon and at least one other channel reconcile their month by hand in a spreadsheet, and two things in that process go wrong without producing an error.

**The amount column means different things on different marketplaces.** Amazon's `item-price` in the order report is already the line total. Shopify's `Lineitem price` is the price of one unit. The column name does not tell you which you have, and summing a unit price row by row under-reports revenue silently. This tool reconciles both readings against the order total that the export already contains and uses whichever one matches, rather than guessing from the header.

**Refund and cancellation wording differs per channel** — `Cancelled`, `Canceled`, `partially_refunded` — so an exact-text filter leaves money in the totals that was never received.

It reads every order-export CSV in a folder regardless of encoding or delimiter, maps each channel's headers onto one set, drops cancelled and refunded rows, totals by product and by channel, and applies fee rates the seller supplies to show a net figure.

If it cannot identify the amount column in a file, it lists that file as skipped and leaves it out rather than producing a total that looks correct.

## Guidelines

- **Alphabetical order:** inserted between `MerchantWords` and `Packrift`
- **Factual description, marketing toned down:** yes — no claims about revenue or savings
- **Diff:** one line added, nothing else changed

Repository: https://github.com/actorlee007-cmyk/multichannel-settlement

MIT licensed, Python 3.6+, standard library only. Runs locally, no account, nothing uploaded. A sample export and the exact output it produces are committed so the behaviour above can be reproduced in one command.

It does not calculate sales tax, track inventory, or connect to Seller Central. Fee rates are supplied by the user, not known by the tool.