### PR TITLE
Add Vaytax German VAT Tools to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@
 - [Splitly](https://splitly.com/) - Algorithmic split testing, automated pricing optimization, keyword rank tracking.
 - [TradeGecko](https://www.tradegecko.com/) - Cloud based inventory and order management software for modern online businesses.
 - [Turbo Piranha](https://www.turbopiranha.com/) - Bulk product search, profit calculation and competition analysis software using UPC, ISBN, EAN and ASIN lists in Excel/CSV/TXT format for wholesale and arbitrage business models, and also book sellers/flippers.
+- [Vaytax German VAT Tools](https://vaytax.com/resources) - Free, no-signup German VAT tools for sellers holding stock in Germany: VAT number validation, tax office (Finanzamt) lookup with a downloadable dataset, VAT and late-filing penalty calculators, an OSS and EORI requirement checker, and the 2026 German VAT deadline calendar as PDF and ICS.
 - [WordTree](https://www.wordtree.io/) - Keyword tools to grow your search traffic, research your competitors, and monitor your niche.
 - [xSellco](https://www.xsellco.com/) - Centralize customer queries, target positive feedback by requesting reviews from happy customers, automatically reprice.
 


### PR DESCRIPTION
Adds a free German VAT toolset to **Software and Tools**, inserted alphabetically between Turbo Piranha and WordTree.

**Disclosure: I am a co-founder of Vaytax.** Flagging that up front rather than having a maintainer find it.

**Why I think it belongs on the list**

Any seller who stores stock in a German Amazon warehouse triggers a German VAT registration from the first order, regardless of turnover. It is one of the most common and most expensive surprises in EU expansion, and the list currently has no tool covering it.

The tools are free, browser-based, and behind no signup or email gate:

- **VAT number validation** against the EU VIES service
- **Finanzamt lookup**, which German tax office is responsible for a foreign company, keyed by country of establishment, with the underlying dataset downloadable
- **VAT and late-filing penalty calculators**, including the § 152 AO surcharge math that most calculators omit
- **OSS and EORI requirement checkers**, which frequently answer "you do not need this", which is the useful answer
- **2026 German VAT deadline calendar** as a printable PDF and a subscribable ICS file

**On the guidelines**

- Not an affiliate link, no tracking parameters, no referral scheme.
- Not a course.
- Description kept factual and free of marketing language, per contributing.md. Happy to trim it further if it reads long.
- If you would rather list one specific tool than the tools hub, say which and I will change the entry, or split it.