### PR TITLE
Add ListingPic to Amazon seller tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
 - [Flapen](https://flapen.com) - Flapen is a free real-time dashboard to monitor Amazon category changes in 19 country and 215 categories
 - [Acalcia](https://acalcia.com) - Free, no-signup browser suite of seller calculators including an Amazon FBA fee and profit calculator, plus pricing, margin, and break-even tools. No login or paywall.
 - [Advigator](https://www.advigator.com) - Amazon Advertising Software
+- [ListingPic](https://listingpic.com/amazon-product-image-checker/) - Free browser-based tool for checking Amazon product images and marketplace listing thumbnails before publishing.
 - [AiHello AutoPilot](https://www.aihello.com/) - Amazon PPC Ads Automation Software.
 - [Amazon Scraper API](https://amazonscraperapi.com) - Production REST API for Amazon product, search, and batch ASIN data across 20 marketplaces. Residential proxies and TLS impersonation handled server-side. 1000 free requests on signup.
 - [Amzmailer](https://amzmailer.com/) - Feedback software and email autoresponder to send Amazon customers automated emails.


### PR DESCRIPTION
Hi, thanks for maintaining this useful list for Amazon sellers.

This PR adds ListingPic, a free browser-based tool for checking Amazon product images and marketplace listing thumbnails before publishing.

I added it under Software and Tools because it helps sellers preview and avoid product image cropping or thumbnail issues.

Happy to adjust the wording or placement if needed.