### PR TITLE
Add Awesome China Sourcing (supplier verification toolkit)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@
 
 ## Other
 
+- [Awesome China Sourcing](https://github.com/assassinationss/awesome-china-sourcing) - Open-source China sourcing toolkit: a six-step supplier verification system (license check, factory video call, reference check), quality inspection checklists, Incoterms cheat sheet, and negotiation templates.
 - [chdh-tools-dataset](https://github.com/launotice-lang/chdh-tools-dataset) - Open dataset (CC BY 4.0) of 1,210 cross-border e-commerce tools, including major Amazon seller tools (Helium 10, Jungle Scout, Keepa, FastMoss). JSON/CSV format with categories, pricing, and editorial ratings.
 - [FBA Catalog](https://fbacatalog.com) - Software catalog for Amazon Sellers. Find tools that fit your business in no time!
 - [FBA Monthly](https://fbamonthly.com) - FBA Monthly newsletter is an across-the-board summary of the month's most important news articles and blog posts regarding Amazon businesses.


### PR DESCRIPTION
Adds [Awesome China Sourcing](https://github.com/assassinationss/awesome-china-sourcing) to the **Other** section.

**Why it is awesome:**

- It open-sources a complete six-step supplier verification system (the **VERIFY** framework: license validation, factory video-call verification, reference checks, cross-channel sampling, written specs, customs/court record checks) — the kind of process normally locked inside sourcing agencies or paid courses.
- Includes practical, downloadable artifacts: quality inspection checklists, an Incoterms cheat sheet, a landed-cost calculator, and negotiation email templates.
- Deep guides on topics Amazon sellers ask about constantly: how to verify a Chinese supplier in 2026, and Alibaba vs 1688 sourcing.
- No signup or lead wall for the core content — a genuine open-source toolkit for private label sellers.

Placed alphabetically in the Other section (before `chdh-tools-dataset`). Happy to adjust the description if needed.