### PR TITLE
Add Seller Calculators to Software and Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.
 - [SellerApp](https://www.sellerapp.com/) - Product research, product ideas, listing quality, product alerts, product source, keyword research, ppc analyzer, and more.
+- [Seller Calculators](https://sellercalculators.com) - Free Amazon fee and profit margin decision tools for multi-channel sellers.
 - [SellerEngine.app](https://sellerengine.app) - EU-hosted operations dashboard for multi-marketplace Amazon sellers; combines PPC, repricing, inventory forecasting, VAT/OSS and listing checks in one daily view.
 - [SellerLabs](https://www.sellerlabs.com/tools/) - Several tools to manage ads, discover profitable keywords and products, get more product reviews and better seller feedback, simplify inventory and financial management for the amazon marketplace.
 - [SellerLegend](https://sellerlegend.com/) - Near real-time orders download, intelligent KPI dashboards, inventory management, notifications, refunds, historical cost of goods, operating expenses, all America & Europe marketplaces, financial transactions, Europe vat.


### PR DESCRIPTION
Hi there! 

I've added Seller Calculators (https://sellercalculators.com) to the Software and Tools section. 

It is a permanently free web utility (no paywalls, sign-up required, or trial limits) featuring interactive fee and profit margin calculators for e-commerce merchants selling on Etsy, Shopify, and Amazon.

Thanks for maintaining this list!