### PR TITLE
Add Pangolinfo (Amazon data MCP + REST API)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@
 - [Keyword Tool](https://keywordtool.io/amazon) - Finds great keywords using Amazon autocomplete.
 - [MerchantWords](https://www.merchantwords.com/) - Finds highly specific keyword phrases that help buyers find what you are selling.
 - [Packrift Packaging Fit Lab](https://packrift.github.io/packaging-fit-lab/) - Free packaging fit tool for comparing item dimensions against carton and mailer options before FBA or merchant-fulfilled shipping.
+- [Pangolinfo](https://www.pangolinfo.com/amazon-data-mcp/) - MCP server and REST API exposing 19 read-only Amazon data tools: product details, reviews, keyword search, category and niche analysis, Best Sellers, New Releases, and seller storefronts, plus WIPO trademark and US PACER patent litigation lookups. Connects over Streamable HTTP; Python client available via `pip install pangolinfo-mcp`.
 - [Prestozon](https://prestozon.com/) - Automation and analytics for Amazon HSA & sponsored products ads.
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.


### PR DESCRIPTION
Adds **Pangolinfo** to **Software and Tools**, in alphabetical order between Packrift and Prestozon.

Why it fits the list: it gives Amazon sellers and the developers building for them a single interface to Amazon marketplace data. Beyond the usual product / review / search / Best Sellers lookups, it also covers seller storefronts, category and niche analysis, and — less common — WIPO trademark and US PACER patent litigation lookups for checking IP risk before listing.

Kept factual per the guidelines:
- 19 read-only tools, Streamable HTTP transport, no local install required
- Python client: `pip install pangolinfo-mcp`
- Listed on the official MCP Registry (`io.github.Pangolin-spg/pangolinfo-mcp`)
- Source: https://github.com/Pangolin-spg/pangolinfo-mcp

No affiliate links. Happy to reword the description if it reads too promotional.