### PR TITLE
Add Costback (free FBA reimbursement calculator)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@
 - [Calcmatic](https://calcmatic.app) - Free profit calculator for Amazon FBA/FBM with full fee breakdown with graphs.
 - [Calcrux FBA Profit Calculator](https://calcrux.com/tools/ecommerce/amazon-fba-profit-calculator) - Free multi-marketplace FBA profit + fee breakdown calculator. Covers inbound placement fees. No sign-up required.
 - [CashCowPro](https://www.cashcowpro.com/) - Sales data, keyword tracking, feedback collection, inventory monitoring, price split testing.
+- [Costback](https://getcostback.com/calculator) - Free calculator that reads a seller's own FBA Reimbursements report to estimate reimbursements owed, updated for Amazon's 2025 manufacturing-cost policy. No login or account access.
 - [DataHawk](https://www.datahawk.co/) - An end-to-end platform, with full data control, intuitive dashboards and AI-powered guidance and automation.
 - [Eva](https://eva.guru/) - Connects the most important aspects of your Amazon business into a single intuitive dashboard - price management, replenishments, reimbursements, analytics.
 - [FeedbackExpress](https://www.feedbackexpress.com/) - Makes it easy to improve your Amazon seller rating through effective, automated feedback requests.


### PR DESCRIPTION
Adds **Costback** to Software and Tools (alphabetical, after CashCowPro).

Why it fits the list: it's a free, no-login calculator that reads a seller's own FBA Reimbursements report to estimate what Amazon still owes them. It's specifically updated for Amazon's March 2025 shift to manufacturing-cost-based reimbursements, which changed the math for every FBA seller and isn't well covered by the existing profit/fee calculators already listed (Calcmatic, Calcrux, Seller Calculators). No account access, no Seller Central login. Description kept factual per contributing.md.