### PR TITLE
Add Lunalisa (AI listing-image tool) to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@
 - [Inventory Hero](https://www.inventoryhero.ai) - Automated inventory management for Amazon FBA that forecasts demand, drafts restocks, and works inside Claude via MCP.
 - [Jungle Scout](https://www.junglescout.com/) - Track and compare key product metrics, database allows you to filter products across multiple categories by demand, price, estimated sales, rating, seasonality, dimensions and more, find out which products sell and which niches have high opportunity.
 - [Keyword Tool](https://keywordtool.io/amazon) - Finds great keywords using Amazon autocomplete.
+- [Lunalisa](https://luna-lisa.art) - AI creative workspace for generating white-background listing shots and marketing images from product photos, with stills up to 4K across 16 aspect ratios. Freemium, free credits on signup.
 - [MerchantWords](https://www.merchantwords.com/) - Finds highly specific keyword phrases that help buyers find what you are selling.
 - [Packrift Packaging Fit Lab](https://packrift.github.io/packaging-fit-lab/) - Free packaging fit tool for comparing item dimensions against carton and mailer options before FBA or merchant-fulfilled shipping.
 - [Pangolinfo](https://www.pangolinfo.com/amazon-data-mcp/) - MCP server and REST API exposing 19 read-only Amazon data tools: product details, reviews, keyword search, category and niche analysis, Best Sellers, New Releases, and seller storefronts, plus WIPO trademark and US PACER patent litigation lookups. Connects over Streamable HTTP; Python client available via `pip install pangolinfo-mcp`.


### PR DESCRIPTION
Adds Lunalisa (https://luna-lisa.art), an AI creative workspace for generating product photography and white-background Amazon listing images from source photos, plus marketing posters and stills up to 4K across 16 aspect ratios. Freemium with free credits on signup. Inserted alphabetically in the Software and Tools section, description kept factual per the contribution guidelines.