### PR TITLE
Add SellerBlaze to Software and Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@
 - [Prisync](https://prisync.com/) - Price monitoring & tracking SaaS with dynamic pricing and automatching engine.
 - [Scrappie](https://scrappie.app) - E-commerce data monitoring and analysis platform with API integration, WebHooks & ETL processes.
 - [SellerApp](https://www.sellerapp.com/) - Product research, product ideas, listing quality, product alerts, product source, keyword research, ppc analyzer, and more.
+- [SellerBlaze](https://sellerblaze.com) - Amazon profit analytics reconciled from actual settlement reports rather than estimated from the published fee schedule, with Sponsored Products bid automation capped at break-even CPC. Includes a free, no-signup [Amazon India fee and profit calculator](https://sellerblaze.com/calculators/amazon-india-fee-calculator) covering referral, closing and weight-handling fees plus GST and TCS.
 - [Seller Calculators](https://sellercalculators.com) - Free Amazon fee and profit margin decision tools for multi-channel sellers.
 - [SellerEngine.app](https://sellerengine.app) - EU-hosted operations dashboard for multi-marketplace Amazon sellers; combines PPC, repricing, inventory forecasting, VAT/OSS and listing checks in one daily view.
 - [SellerLabs](https://www.sellerlabs.com/tools/) - Several tools to manage ads, discover profitable keywords and products, get more product reviews and better seller feedback, simplify inventory and financial management for the amazon marketplace.


### PR DESCRIPTION
Adding SellerBlaze.

**Why it belongs here:** the linked fee calculator is genuinely free with no signup, no login and no paywall, and it handles Indian **GST and TCS** alongside referral, closing and weight-handling fees — every other Amazon calculator I could find covers US/EU fee structures only.

**Accuracy note so nobody has to check it themselves:** profit reconciliation is settlement-certified for Amazon India today; other marketplaces are shown as clearly-labelled estimates rather than claimed as certified. Ad automation covers Sponsored Products only — not Sponsored Brands, Sponsored Display or DSP.

Happy to adjust the wording or move it to a different section if you would prefer.

Placed alphabetically after SellerApp in Software and Tools.