### PR TITLE
Update Awesome China Sourcing entry: red-flag checker, landed-cost calculator, deep guides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@
 
 ## Other
 
-- [Awesome China Sourcing](https://github.com/assassinationss/awesome-china-sourcing) - Open-source China sourcing toolkit: a six-step supplier verification system (license check, factory video call, reference check), quality inspection checklists, Incoterms cheat sheet, and negotiation templates.
+- [Awesome China Sourcing](https://github.com/assassinationss/awesome-china-sourcing) - Open-source China sourcing toolkit: six-step supplier verification system, 10-point red-flag checker, landed-cost calculator, quality inspection checklists, Incoterms cheat sheet, negotiation email templates, and deep guides on reading Chinese business licenses and Alibaba vs 1688.
 - [chdh-tools-dataset](https://github.com/launotice-lang/chdh-tools-dataset) - Open dataset (CC BY 4.0) of 1,210 cross-border e-commerce tools, including major Amazon seller tools (Helium 10, Jungle Scout, Keepa, FastMoss). JSON/CSV format with categories, pricing, and editorial ratings.
 - [FBA Catalog](https://fbacatalog.com) - Software catalog for Amazon Sellers. Find tools that fit your business in no time!
 - [FBA Monthly](https://fbamonthly.com) - FBA Monthly newsletter is an across-the-board summary of the month's most important news articles and blog posts regarding Amazon businesses.


### PR DESCRIPTION
The entry merged in #52 has grown since August — this updates the description to reflect what the toolkit actually ships now:

- **10-point red-flag checker** (interactive, launched late August)
- **Landed-cost calculator** (FOB/DDP spread, duties, freight)
- **Deep guides**: [How to Read a Chinese Business License](https://github.com/assassinationss/awesome-china-sourcing/blob/main/docs/how-to-read-a-chinese-business-license.md) (field-by-field decoding + the four-name check) and [Alibaba vs 1688 in 2026](https://github.com/assassinationss/awesome-china-sourcing/blob/main/docs/alibaba-vs-1688-2026.md)

Still the same repo, same verify-first mission — just more of it. Keeping the Amazon-seller audience in mind: the landed-cost calculator in particular answers the "what does this SKU actually cost me" question before the first PO.